### PR TITLE
fix(links): load 'links' namespace on LinkComplete page

### DIFF
--- a/pages/links/complete.tsx
+++ b/pages/links/complete.tsx
@@ -53,7 +53,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ['common'])),
+      ...(await serverSideTranslations(locale, ['common', 'links'])),
     },
   };
 };


### PR DESCRIPTION
Fixes #8  

## Summary
Load the `links` translation namespace on the LinkComplete page so the Steps component renders the translated step labels instead of literal keys.

## Changes
- Added `links` to serverSideTranslations(...) in `pages/link-complete.tsx`

## How to test
1. Checkout my branch: `git fetch origin && git checkout fix/load-links-namespace`
2. Run dev server: `yarn dev`
3. Navigate to the flow and land on the final step - labels should show "Answer / Link", "Contents", "Complete" (not `steps.one`).

## Screenshots
<img width="526" height="280" alt="image" src="https://github.com/user-attachments/assets/5ee2d879-2ac2-4401-94ef-5cfd26a4c079" />

